### PR TITLE
few edits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Imports:
     edgeR,
     ggrepel,
     plotly,
-    airway
+    airway,
+    ggpubr
 Suggests: 
     knitr, 
     rmarkdown,

--- a/vignettes/tidytranscriptomics.Rmd
+++ b/vignettes/tidytranscriptomics.Rmd
@@ -304,7 +304,7 @@ counts_scaled
 
 After we run `scale_abundance()` we should see some columns have been added at the end. We have a column called `lowly_abundant` that indicates whether the gene has been filtered due to being lowly expressed. FALSE means the gene wasn’t filtered, TRUE means it was. The `count_scaled` column contains the scaled counts.
 
-We can now see the difference of abundance densities before and adfter scaling
+We can now see the difference of abundance densities before and after scaling
 
 ```{r}
 counts_scaled %>%

--- a/vignettes/tidytranscriptomics.Rmd
+++ b/vignettes/tidytranscriptomics.Rmd
@@ -398,7 +398,7 @@ counts_scal_MDS %>%
 	      .row = transcript,
 	      .value = count_scaled,
 	      annotation = c(dex, cell),
-	      transform = function(x) x %>% log1p %>% tidyHeatmap:::scale_robust()
+	      transform = log1p
 	  )
 ```
 

--- a/vignettes/tidytranscriptomics.Rmd
+++ b/vignettes/tidytranscriptomics.Rmd
@@ -85,7 +85,7 @@ The tidytranscriptomics approach to RNA sequencing data analysis abstracts out t
 This material is adapted from an R for RNA-Seq workshop first run [here](http://combine-australia.github.io/2016-05-11-RNAseq/).
 
 
-`r knitr::include_graphics(system.file(package='tidytranscriptomics', 'vignettes', 'tidybulk_logo.png'))`
+`r knitr::include_graphics(system.file(package='tidytranscriptomics',  'vignettes', 'tidybulk_logo.png'))`
 
 
 # Overview
@@ -245,22 +245,22 @@ The bar plots show us there are 15-30 million counts per sample.
 # Filtering lowly expressed genes  
 Genes with very low counts across all libraries provide little evidence for differential expression and they interfere with some of the statistical approximations that are used later in the pipeline. They also add to the multiple testing burden when estimating false discovery rates, reducing power to detect differentially expressed genes. These genes should be filtered out prior to further analysis.
 
-tidybulk can automatically filter out lowly expressed genes. It uses the edgeR filterByExpr function described [here](https://f1000research.com/articles/5-1408). This will keep genes with ~10 counts in a minimum number of samples, the number of the samples in the smallest group. In this dataset the smallest group size is 2 samples. tidybulk performs this filtering in the functions we will use `scale_abundance()` and `test_differential_abundance()` and we can take a look at it with `keep_abundant()`.
+With tidybulk, it is not really needed to explicitly filter lowly transcribed genes as all calulations (e.g., scaling, removal unwanted variation, differential expression testing) are done on abundantly transcribed genes; although in case of scaling, it is apllied back on all transcripts.
+
+However, to explicitly and/or temporarly drop them from the data set is useful for data visualisation. Tidybulk, uses the edgeR filterByExpr function described [here](https://f1000research.com/articles/5-1408). By default, this will keep genes with ~10 counts in a minimum number of samples, the number of the samples in the smallest group. In this dataset the smallest group size is 2 samples. tidybulk performs this filtering in the functions we will use `scale_abundance()` and `test_differential_abundance()` and we can explicitely apply it with `keep_abundant()`.
 
 ```{r}
-# Filtering out lowly abundant genes 
-counts_filt <- counts_aggr %>% 
+# Take a look to only highly abundant genes 
+counts_aggr %>% 
   keep_abundant(factor_of_interest = dex)
-
-# take a look
-counts_filt
 ```
 
 We can create density plots to view the distributions of the counts for the samples. This is also a quality check to see if the samples look similar and that none look majorly different. Note we need to log the counts which we can do by using `scale_x_log10()` We need to add a small offset (1) to the counts to avoid taking log of zero.
 
 ```{r}
 # density plot after filtering 
-counts_filt %>% 
+counts_aggr %>% 
+	keep_abundant(factor_of_interest = dex) %>%
   ggplot(aes(x=count + 1, group=sample, color=dex)) +
   geom_density() +
   scale_x_log10() +
@@ -271,7 +271,8 @@ These samples all look pretty similar, none are majorly different.
 
 We can count how many genes there are after filtering.
 ```{r}
-counts_filt %>% 
+counts_aggr %>% 
+	keep_abundant(factor_of_interest = dex) %>%
   summarise(num_genes = n_distinct(transcript))
 ```
 
@@ -285,7 +286,7 @@ TMM normalisation is performed to eliminate composition biases between libraries
 
 ```{r}
 # Scaling counts for library size and composition bias
-counts_scaled <- counts_filt %>% scale_abundance(factor_of_interest = dex)
+counts_scaled <- counts_aggr %>% scale_abundance(factor_of_interest = dex)
 
 # take a look
 counts_scaled
@@ -311,7 +312,7 @@ We can also create box plots to check the distributions of the counts in the sam
 ```{r}
 # box plot after scaling
 counts_scaled %>% 
-  filter(lowly_abundant == FALSE) %>%
+  filter(!lowly_abundant) %>%
   ggplot(aes(x=sample, y=count_scaled + 1, fill=dex)) +
   geom_boxplot() +
   geom_hline(aes(yintercept = median(count_scaled + 1)), colour = 'red', show.legend = FALSE) +
@@ -387,7 +388,7 @@ counts_scal_MDS %>%
 	      .row = transcript,
 	      .value = count_scaled,
 	      annotation = c(dex, cell),
-	      transform = function(x) x %>% log1p %>% tidyHeatmap:::scale_robust()
+	      transform = log1p 
 	  )
 ```
 
@@ -475,7 +476,7 @@ MA plots enable us to visualise **amount** of expression (logCPM) versus logFC. 
 # maplot, minimal
 counts_de_pretty %>%
   pivot_transcript() %>%
-  filter(lowly_abundant == FALSE) %>%
+  filter(!lowly_abundant) %>%
   ggplot(aes(x=logCPM, y=-logFC, colour=significant)) +
   geom_point()+
 	theme_bw()
@@ -488,6 +489,7 @@ counts_de_pretty %>%
     pivot_transcript() %>%
 
     # Subset data
+		filter(!lowly_abundant) %>%
     mutate(significant = FDR<0.05 & abs(logFC) >=2) %>%
     mutate(transcript = ifelse(abs(logFC) >=5, as.character(transcript), "")) %>%
 
@@ -507,7 +509,7 @@ Volcano plots enable us to visualise **significance** of expression (P value) ve
 ```{r}
 # volcanoplot, minimal
 counts_de_pretty %>%
-  filter(lowly_abundant == FALSE) %>%
+  filter(!lowly_abundant) %>%
   ggplot(aes(x=logFC, y=-log10(PValue), colour=significant)) +
   geom_point() +
 	theme_bw()
@@ -520,6 +522,7 @@ counts_de_pretty %>%
     pivot_transcript() %>%
 
     # Subset data
+		filter(!lowly_abundant) %>%
     mutate(significant = FDR<0.05 & abs(logFC) >=2) %>%
     mutate(transcript = ifelse(transcript %in% topgenes_symbols, as.character(transcript), "")) %>%
 

--- a/vignettes/tidytranscriptomics.Rmd
+++ b/vignettes/tidytranscriptomics.Rmd
@@ -250,7 +250,7 @@ With tidybulk, it is not really necessary to explicitly filter lowly transcribed
 However, to explicitly and/or temporarly drop them from the data set is useful for data visualisation. Tidybulk, uses the edgeR filterByExpr function described [here](https://f1000research.com/articles/5-1408). By default, this will keep genes with ~10 counts in a minimum number of samples, the number of the samples in the smallest group. In this dataset the smallest group size is 2 samples. tidybulk performs this filtering in the functions we will use `scale_abundance()` and `test_differential_abundance()` and we can explicitely apply it with `keep_abundant()`.
 
 ```{r}
-# Take a look to only highly abundant genes 
+# Take a look at the abundant genes
 counts_aggr %>% 
   keep_abundant(factor_of_interest = dex)
 ```

--- a/vignettes/tidytranscriptomics.Rmd
+++ b/vignettes/tidytranscriptomics.Rmd
@@ -176,21 +176,10 @@ counts_long
 ```
 
 
-We will next extract just the columns we need, sample, transcript, count.
-
-```{r}
-# using pipe
-counts_long_sel <- counts_long %>% 
-  select(sample, transcript, count)
-
-# take a look 
-counts_long_sel
-```
-
 Now we have our counts matrix in the long format, we will join it to our sampleinfo so we have information on the samples, what groups they belong to. The join will use all columns with the same name to join. Here we have a column called "sample" in both tables so that will be used to join the two tables.
 
 ```{r}
-counts_annot <- left_join(counts_long_sel, sampleinfo)
+counts_annot <- left_join(counts_long, sampleinfo)
 
 # take a look
 counts_annot

--- a/vignettes/tidytranscriptomics.Rmd
+++ b/vignettes/tidytranscriptomics.Rmd
@@ -119,6 +119,7 @@ library(tidyHeatmap)
 library(tidybulk)
 library(plotly)
 library(airway)
+library(ggpubr)
 ```
 
 ## Airway RNA-seq dataset
@@ -229,7 +230,7 @@ Some gene symbols are not unique, they map to more than one gene id. We need to 
 counts_aggr <- aggregate_duplicates(counts_tt) 
 
 # remove genes with NA for symbol
-counts_aggr <- drop_na(counts_aggr, transcript)
+counts_aggr <- filter(counts_aggr, !is.na(transcript))
 ```
 
 We can check how many counts we have for each sample by making a bar plot. This helps us see whether there are any major discrepancies between the samples more easily. We use weight= to sum up the counts for each sample.
@@ -240,6 +241,7 @@ ggplot(counts_aggr, aes(x=sample, weight=count, fill=dex)) +
   geom_bar()+
 	theme_bw()
 ```
+
 We can also easily view by cell line (or any other variable that's a column in our dataset) simply by changing fill=.
 
 ```{r}
@@ -272,7 +274,7 @@ We can create density plots to view the distributions of the counts for the samp
 counts_filt %>% 
   ggplot(aes(x=count + 1, group=sample, color=dex)) +
   geom_density() +
-  scale_x_log10()+
+  scale_x_log10() +
 	theme_bw()
 ```
 
@@ -301,6 +303,19 @@ counts_scaled
 ```
 
 After we run `scale_abundance()` we should see some columns have been added at the end. We have a column called `lowly_abundant` that indicates whether the gene has been filtered due to being lowly expressed. FALSE means the gene wasn’t filtered, TRUE means it was. The `count_scaled` column contains the scaled counts.
+
+We can now see the difference of abundance densities before and adfter scaling
+
+```{r}
+counts_scaled %>%
+	pivot_longer(cols = contains("count"), names_to = "source", values_to = "abundance") %>%
+  ggplot(aes(x=abundance + 1, group=sample, color=dex)) +
+	geom_density() +
+	facet_wrap(~source) +
+	scale_x_log10() +
+	theme_bw()
+	
+```
 
 We can also create box plots to check the distributions of the counts in the samples. We can add a line through the median with to help us see how similar (or not) the distributions are.
 
@@ -337,7 +352,7 @@ counts_scal_MDS <-
 counts_scal_MDS
 ```
 
-Then we can select just the dimensions for the samples.
+For plotting, we can select just the dimensions for the samples.
 
 ```{r}
 # get the dimensions with all metadata
@@ -375,11 +390,7 @@ An alternative to MDS for examining relationships between samples is using hiera
 counts_scal_MDS %>% 
 	
 	# extract 500 most variable genes
-	keep_variable(
-	              .sample = sample, 
-	              .transcript = transcript, 
-	              .abundance = count_scaled, 
-	              top = 500) %>%
+	keep_variable( .abundance = count_scaled, top = 500) %>%
 		
 	# create heatmap
 	heatmap(
@@ -387,7 +398,7 @@ counts_scal_MDS %>%
 	      .row = transcript,
 	      .value = count_scaled,
 	      annotation = c(dex, cell),
-	      transform = log1p
+	      transform = function(x) x %>% log1p %>% tidyHeatmap:::scale_robust()
 	  )
 ```
 
@@ -547,8 +558,10 @@ counts_de_pretty %>%
 	filter(transcript %in% topgenes_symbols) %>%
 	
 	# make stripchart
-	ggplot(aes(x = dex, y = count_scaled + 1, colour = dex)) +
+	ggplot(aes(x = dex, y = count_scaled + 1, fill = dex)) +
+	geom_boxplot() +
 	geom_jitter() +
+	stat_compare_means(comparisons = list(c("trt", "untrt"))) +
 	facet_wrap(~transcript) +
 	scale_y_log10()+
 	theme_bw()
@@ -565,8 +578,10 @@ p <- counts_de_pretty %>%
 	filter(transcript %in% topgenes_symbols) %>%
 	
 	# make stripchart
-	ggplot(aes(x = dex, y = count_scaled + 1, colour = dex, label = sample)) +
+	ggplot(aes(x = dex, y = count_scaled + 1, fill = dex, label = sample)) +
+	geom_boxplot() +
 	geom_jitter() +
+	stat_compare_means(comparisons = list(c("trt", "untrt"))) +
 	facet_wrap(~transcript) +
 	scale_y_log10()+
 	theme_bw()

--- a/vignettes/tidytranscriptomics.Rmd
+++ b/vignettes/tidytranscriptomics.Rmd
@@ -245,7 +245,7 @@ The bar plots show us there are 15-30 million counts per sample.
 # Filtering lowly expressed genes  
 Genes with very low counts across all libraries provide little evidence for differential expression and they interfere with some of the statistical approximations that are used later in the pipeline. They also add to the multiple testing burden when estimating false discovery rates, reducing power to detect differentially expressed genes. These genes should be filtered out prior to further analysis.
 
-With tidybulk, it is not really needed to explicitly filter lowly transcribed genes as all calulations (e.g., scaling, removal unwanted variation, differential expression testing) are done on abundantly transcribed genes; although in case of scaling, it is apllied back on all transcripts.
+With tidybulk, it is not really necessary to explicitly filter lowly transcribed genes, as all calculations (e.g., scaling, removal of unwanted variation, differential expression testing) are performed on abundantly transcribed genes; although in case of scaling, the scaling is applied back to all genes in the dataset.
 
 However, to explicitly and/or temporarly drop them from the data set is useful for data visualisation. Tidybulk, uses the edgeR filterByExpr function described [here](https://f1000research.com/articles/5-1408). By default, this will keep genes with ~10 counts in a minimum number of samples, the number of the samples in the smallest group. In this dataset the smallest group size is 2 samples. tidybulk performs this filtering in the functions we will use `scale_abundance()` and `test_differential_abundance()` and we can explicitely apply it with `keep_abundant()`.
 


### PR DESCRIPTION
Just few comments:

-	The beauty of having a tidy dataset is that you can not think about subsetting information “We will next extract just the columns we need, sample, transcript, count.” For example if lateron we want to visualise ensembl ID after analyses we can easily because we have that column.  We can forget about it until we need it. Pretty convenient!

I have done nothing here

-	Similarly, I would not hard-filter abundant genes. All analyses will be done on abundant genes anyway (unless I am missing something). So we can filter for plotting for example but I don’t think we need to delete any transcript from the data set

I have done nothing here

-	For “We can also create box plots to check the distributions of the counts in the samples” after scaling, I think we could first show the densities similarly to before so to see the difference. Even better I think is really good to see the potentiality of tidy data is to gather(c(count, count_caled), c(“source”, “abundance)) %>% ggplot + geom_density + facet_wrap(~source). Facetting based on whether scaled or not, one next to the other (added to document for feedback)
-	drop_na, is not implemented in tidybulk yet and will strip the internals 😊 I replaced with filter()

Please review the changes and keep if you like.