### PR TITLE
Update biocViews

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     rmarkdown,
     pkgdown
 Biarch: true
-biocViews: AssayDomain, Infrastructure
+biocViews: Clustering, DifferentialExpression, GeneExpression, Normalization, QualityControl, RNASeq, Sequencing, Transcription, Transcriptomics
 URL: https://stemangiola.github.io/bioc_2020_tidytranscriptomics/
 BugReports: https://github.com/stemangiola/bioc_2020_tidytranscriptomics/issues/new/choose
 VignetteBuilder: knitr


### PR DESCRIPTION
Heya,

To meet the FAIR recommendations we need a field for keywords, which in our case is the biocViews field in the DESCRIPTION file. The workshop copies the tidybulk biocViews and I noticed they're pretty sparse e.g no bio keywords like "Transcriptomics", so I'm going to add some from edgeR below (as we're using that), ones that I think are relevant for the workshop. What do you think? (maybe could add some more biocViews to tidybulk package too?)

EdgeR has these biocViews (I see here: https://bioconductor.org/packages/release/bioc/html/edgeR.html):

AlternativeSplicing, BatchEffect, Bayesian, BiomedicalInformatics, CellBiology, ChIPSeq, Clustering, Coverage, DNAMethylation, DifferentialExpression, DifferentialMethylation, DifferentialSplicing, Epigenetics, FunctionalGenomics, GeneExpression, GeneSetEnrichment, Genetics, ImmunoOncology, MultipleComparison, Normalization, Pathways, QualityControl, RNASeq, Regression, SAGE, Sequencing, Software, SystemsBiology, TimeCourse, Transcription, Transcriptomics