### PR TITLE
Update README install_github to use tidybulk v1.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ You should see the Rmarkdown file with all the workshop code which you can run.
 Alternatively, you could install the workshop using the commands below in R `4.0`.
 
 ```
-devtools::install_github("stemangiola/tidybulk")
+devtools::install_github("stemangiola/tidybulk@v1.1.5")
 devtools::install_github("stemangiola/bioc_2020_tidytranscriptomics", build_vignettes = TRUE)
 library(bioc2020tidytranscriptomics)
-vignette("bioc2020tidytranscriptomics")
+browseVignettes("bioc2020tidytranscriptomics")
 ```
 
 To run the code, you could then copy and paste the code from the workshop [R markdown file](https://raw.githubusercontent.com/stemangiola/bioc_2020_tidytranscriptomics/master/vignettes/tidytranscriptomics.Rmd) into a new R Markdown file on your computer.


### PR DESCRIPTION
Adding this so that people can install the same tidybulk version used in this workshop (if they don't want to use the Docker image).
Also changing to use `browseVignettes("bioc2020tidytranscriptomics")` as `vignette("bioc2020tidytranscriptomics")` doesn't work, think since I added the additional vignette files (for solutions & supplmentary).
Also now I see the figure widths don't look so nice in the built vignette html, something to try to improve for next workshop.